### PR TITLE
hash body only when POST and body not empty

### DIFF
--- a/client.go
+++ b/client.go
@@ -127,7 +127,7 @@ func dataToSign(method, requestURL string, authHeader string, headers http.Heade
 		parsedURL.Host,
 		parsedURL.Path + parsedURL.RawQuery,
 		"",
-		Compute256(body),
+		body,
 		authHeader,
 	}
 

--- a/client.go
+++ b/client.go
@@ -121,13 +121,18 @@ func dataToSign(method, requestURL string, authHeader string, headers http.Heade
 		return ""
 	}
 
+	bodyHash := ""
+	if method == "POST" && len(body) > 0 {
+		bodyHash = Compute256(body)
+	}
+
 	dataToSign := []string{
 		method,
 		parsedURL.Scheme,
 		parsedURL.Host,
 		parsedURL.Path + parsedURL.RawQuery,
 		"",
-		body,
+		bodyHash,
 		authHeader,
 	}
 


### PR DESCRIPTION
This is not required by the spec and yields a "signature does not match" (401) response.